### PR TITLE
Fix missing video on homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,5 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The Void Architecture</title>
 </head>
-<body></body>
+<body style="color: #eeeeee;">
+  <div style="text-align: center;">
+    <video width="540" height="540" autoplay muted loop>
+      <source src="void-arc/and-then-something-amazing-happened.mp4" type="video/mp4" />
+    </video>
+  </div>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- embed the video again in docs/index.html to restore content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c934391cc832890962d4fb7a6b60a