### PR TITLE
Add Flask front-end for sampling and incremental video names

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from flask import Flask, request, jsonify, send_from_directory
+from sample_media.sample_media import (
+    sample_from_media_library,
+    fetch_videos_from_erc721,
+    fetch_media_from_erc1155,
+)
+
+app = Flask(__name__)
+BASE_DIR = Path(__file__).parent
+LIBRARY_DIR = BASE_DIR / "sample-media" / "library_dir"
+OUTPUT_DIR = BASE_DIR / "sample-media" / "output_dir"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def latest_video() -> Path | None:
+    videos = sorted(OUTPUT_DIR.glob("final_*.mp4"))
+    return videos[-1] if videos else None
+
+
+@app.route("/videos")
+def get_latest_video():
+    vid = latest_video()
+    return jsonify({"video": vid.name if vid else None})
+
+
+@app.route("/videos/<path:filename>")
+def serve_video(filename):
+    return send_from_directory(OUTPUT_DIR, filename)
+
+
+@app.route("/api/sample", methods=["POST"])
+def api_sample():
+    data = request.get_json(force=True)
+    contract = data.get("contract")
+    samples = int(data.get("samples", 1))
+    duration = float(data.get("duration", 1))
+
+    # Placeholder: in future fetch from ERC-721/1155 using contract address
+    # For now we just sample from the local library
+    try:
+        video_path = sample_from_media_library(LIBRARY_DIR, OUTPUT_DIR, samples, duration)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+    return jsonify({"video": video_path.name})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,60 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The Void Architecture</title>
+  <style>
+    body { font-family: Arial, sans-serif; background:#f5f5f5; color:#333; padding:20px; }
+    .container { max-width:600px; margin:0 auto; }
+    video { width:100%; height:auto; margin-bottom:20px; background:#000; }
+    input, button { width:100%; padding:8px; margin-top:5px; box-sizing:border-box; }
+    label { margin-top:10px; display:block; }
+    button { cursor:pointer; }
+  </style>
 </head>
-<body></body>
+<body>
+  <div class="container">
+    <video id="finalVideo" controls></video>
+    <form id="sampleForm">
+      <label for="contract">Ethereum Contract Address</label>
+      <input type="text" id="contract" required />
+      <label for="samples">Samples per file</label>
+      <input type="number" id="samples" value="1" min="1" />
+      <label for="duration">Clip duration (seconds)</label>
+      <input type="number" id="duration" value="1" min="0.1" step="0.1" />
+      <button type="submit">Generate Video</button>
+    </form>
+  </div>
+  <script>
+    async function loadLatestVideo() {
+      const res = await fetch('/videos');
+      if(res.ok) {
+        const data = await res.json();
+        if(data.video) {
+          document.getElementById('finalVideo').src = '/videos/' + data.video;
+        }
+      }
+    }
+
+    document.getElementById('sampleForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const contract = document.getElementById('contract').value;
+      const samples = document.getElementById('samples').value;
+      const duration = document.getElementById('duration').value;
+      const res = await fetch('/api/sample', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contract, samples, duration })
+      });
+      if(res.ok) {
+        const data = await res.json();
+        if(data.video) {
+          document.getElementById('finalVideo').src = '/videos/' + data.video;
+        }
+      } else {
+        alert('Error generating video');
+      }
+    });
+
+    loadLatestVideo();
+  </script>
+</body>
 </html>

--- a/sample-media/README.md
+++ b/sample-media/README.md
@@ -22,10 +22,10 @@ python sample-media/sample_media.py sample-media/library_dir sample-media/output
 ```
 
 - `library_dir` is a folder containing supported media files (images, video, or audio) to sample from.
-- `output_dir` will contain the extracted frame images, audio snippets, and the final video `final.mp4`.
+- `output_dir` will contain the extracted frame images, audio snippets, and the generated video files. Each run creates an incremented file like `final_001.mp4`, `final_002.mp4`, and so on.
 - `--samples` defines how many random samples to pull from each file.
 - `--duration` sets the length (in seconds) of each sampled clip.
 
 ## ERC-721 Support
 
-A stub function `fetch_videos_from_erc721` is provided for future integration with Ethereum collections via IPFS. It is currently not implemented.
+A stub function `fetch_videos_from_erc721` is provided for future integration with Ethereum collections via IPFS. It is currently not implemented. An additional stub `fetch_media_from_erc1155` exists for ERC-1155 collections.

--- a/sample-media/sample_media.py
+++ b/sample-media/sample_media.py
@@ -95,7 +95,16 @@ def sample_from_media_library(
         raise ValueError("No media files found in library_dir")
 
     final_clip = concatenate_videoclips(clips, method="compose")
-    final_video_path = output_dir / "final.mp4"
+
+    def _next_video_path() -> Path:
+        i = 1
+        while True:
+            candidate = output_dir / f"final_{i:03d}.mp4"
+            if not candidate.exists():
+                return candidate
+            i += 1
+
+    final_video_path = _next_video_path()
     final_clip.write_videofile(str(final_video_path), codec="libx264", audio_codec="aac")
     final_clip.close()
     for c in clips:
@@ -109,6 +118,14 @@ def fetch_videos_from_erc721(collection_address: str, destination: Path) -> List
     This function is not implemented and exists as a stub for future work.
     """
     raise NotImplementedError("Fetching from ERC-721 collections is not yet implemented.")
+
+
+def fetch_media_from_erc1155(collection_address: str, destination: Path) -> List[Path]:
+    """Placeholder for fetching media from an ERC-1155 collection via IPFS.
+
+    This function is not implemented and exists as a stub for future work.
+    """
+    raise NotImplementedError("Fetching from ERC-1155 collections is not yet implemented.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a simple Flask server (`app.py`) to generate videos and expose a minimal API
- extend sampling script to increment output video names and add ERC‑1155 stub
- update docs with a clean UI for contract input and video display
- document new behaviour in sample-media README

## Testing
- `python -m py_compile app.py sample-media/sample_media.py`


------
https://chatgpt.com/codex/tasks/task_e_685d49b2993083288b443379bac0daad